### PR TITLE
Provide a new Java Rule for enforcing naming conventions for constants

### DIFF
--- a/src/main/java/com/enofex/taikai/java/NamingConfigurer.java
+++ b/src/main/java/com/enofex/taikai/java/NamingConfigurer.java
@@ -1,6 +1,7 @@
 package com.enofex.taikai.java;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.enofex.taikai.TaikaiRule;
@@ -8,9 +9,11 @@ import com.enofex.taikai.TaikaiRule.Configuration;
 import com.enofex.taikai.configures.AbstractConfigurer;
 import com.enofex.taikai.configures.ConfigurerContext;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.regex.Pattern;
 
 public final class NamingConfigurer extends AbstractConfigurer {
 
@@ -45,6 +48,34 @@ public final class NamingConfigurer extends AbstractConfigurer {
         if (clazz.getSimpleName().startsWith("I") && Character.isUpperCase(
             clazz.getSimpleName().charAt(1))) {
           events.add(SimpleConditionEvent.violated(clazz, clazz.getSimpleName()));
+        }
+      }
+    };
+  }
+
+  public NamingConfigurer constantsShouldFollowConvention() {
+    return constantsShouldFollowConvention(null);
+  }
+
+  public NamingConfigurer constantsShouldFollowConvention(Configuration configuration) {
+    return addRule(TaikaiRule.of(fields().that().areFinal().and().areStatic()
+        .should(shouldFollowConstantNamingConvention())
+        .as("Constants should follow constant naming convention"), configuration));
+  }
+
+  private static ArchCondition<JavaField> shouldFollowConstantNamingConvention() {
+    return new ArchCondition<>("follow constant naming convention") {
+
+      private static final Pattern CONSTANT_NAME_PATTERN = Pattern.compile("^[A-Z][A-Z0-9_]*$");
+
+      @Override
+      public void check(JavaField field, ConditionEvents events) {
+        if (!field.getOwner().isEnum()
+            && !CONSTANT_NAME_PATTERN.matcher(field.getName()).matches()) {
+          String message = String.format(
+              "Constant %s in class %s does not follow the naming convention",
+              field.getName(), field.getOwner().getName());
+          events.add(SimpleConditionEvent.violated(field, message));
         }
       }
     };

--- a/src/test/java/com/enofex/taikai/ArchitectureTest.java
+++ b/src/test/java/com/enofex/taikai/ArchitectureTest.java
@@ -24,7 +24,8 @@ class ArchitectureTest {
                 .shouldNotImport("org.junit.."))
             .naming(naming -> naming
                 .classesShouldNotMatch(".*Impl")
-                .interfacesShouldNotHavePrefixI()))
+                .interfacesShouldNotHavePrefixI()
+                .constantsShouldFollowConvention()))
         .build()
         .check();
   }

--- a/src/test/java/com/enofex/taikai/Usage.java
+++ b/src/test/java/com/enofex/taikai/Usage.java
@@ -42,6 +42,7 @@ class Usage {
                 .shouldNotImport("org.junit.."))
             .naming(naming -> naming
                 .classesShouldNotMatch(".*Impl")
+                .constantsShouldFollowConvention()
                 .interfacesShouldNotHavePrefixI()))
         .build();
 


### PR DESCRIPTION
Closes gb-13