### PR TITLE
Add new controller rule enforcing use of @Validated

### DIFF
--- a/src/main/java/com/enofex/taikai/spring/ControllersConfigurer.java
+++ b/src/main/java/com/enofex/taikai/spring/ControllersConfigurer.java
@@ -3,9 +3,11 @@ package com.enofex.taikai.spring;
 import static com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration;
 import static com.enofex.taikai.spring.SpringDescribedPredicates.ANNOTATION_CONTROLLER;
 import static com.enofex.taikai.spring.SpringDescribedPredicates.ANNOTATION_REST_CONTROLLER;
+import static com.enofex.taikai.spring.SpringDescribedPredicates.ANNOTATION_VALIDATED;
 import static com.enofex.taikai.spring.SpringDescribedPredicates.annotatedWithController;
 import static com.enofex.taikai.spring.SpringDescribedPredicates.annotatedWithControllerOrRestController;
 import static com.enofex.taikai.spring.SpringDescribedPredicates.annotatedWithRestController;
+import static com.enofex.taikai.spring.SpringDescribedPredicates.annotatedWithValidated;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.be;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.dependOnClassesThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.not;
@@ -109,6 +111,28 @@ public class ControllersConfigurer extends AbstractConfigurer {
         .that(are(annotatedWithControllerOrRestController(true)))
         .should(not(dependOnClassesThat(are(annotatedWithControllerOrRestController(true)))))
         .as("Controllers should not be depend on other Controllers"), configuration));
+  }
+
+  public ControllersConfigurer shouldBeAnnotatedWithValidated() {
+    return shouldBeAnnotatedWithRestController(DEFAULT_CONTROLLER_NAME_MATCHING,
+          defaultConfiguration());
+  }
+
+  public ControllersConfigurer shouldBeAnnotatedWithValidated(Configuration configuration) {
+    return shouldBeAnnotatedWithRestController(DEFAULT_CONTROLLER_NAME_MATCHING, configuration);
+  }
+
+  public ControllersConfigurer shouldBeAnnotatedWithValidated(String regex) {
+    return shouldBeAnnotatedWithRestController(regex, defaultConfiguration());
+  }
+
+  public ControllersConfigurer shouldBeAnnotatedWithValidated(String regex,
+        Configuration configuration) {
+    return addRule(TaikaiRule.of(classes()
+                .that().haveNameMatching(regex)
+                .should(be(annotatedWithValidated(true)))
+                .as("Controllers should be annotated with %s".formatted(ANNOTATION_VALIDATED)),
+          configuration));
   }
 
   public static final class Disableable extends ControllersConfigurer implements

--- a/src/test/java/com/enofex/taikai/Usage.java
+++ b/src/test/java/com/enofex/taikai/Usage.java
@@ -244,6 +244,12 @@ class Usage {
                 .shouldBeAnnotatedWithRestController("regex")
                 .shouldBeAnnotatedWithRestController("regex", defaultConfiguration())
 
+                .shouldBeAnnotatedWithValidated()
+                .shouldBeAnnotatedWithValidated(defaultConfiguration())
+
+                .shouldBeAnnotatedWithValidated("regex")
+                .shouldBeAnnotatedWithValidated("regex", defaultConfiguration())
+
                 .shouldNotDependOnOtherControllers()
                 .shouldNotDependOnOtherControllers(defaultConfiguration())
 


### PR DESCRIPTION
Hi!

I think it would be useful to have another rule checking that all controllers are annotated with `@Validated` otherwise validation annotations on `RequestParams` or `PathVariables` won't be checked.  

@mnhock what do you think about that proposal? Is it to specific?