### PR TITLE
Fix the example methodsShouldNotMatch, it was a double negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ void shouldFulfillConstraints() {
               .shouldNotImport("org.junit.."))
           .naming(naming -> naming
               .classesShouldNotMatch(".*Impl")
-              .methodsShouldNotMatch("^(?!foo$|bar$).*")
+              .methodsShouldNotMatch("^(foo$|bar$).*")
               .fieldsShouldNotMatch(".*(List|Set|Map)$")
               .fieldsShouldMatch("com.enofex.taikai.Matcher", "matcher")
               .constantsShouldFollowConventions()


### PR DESCRIPTION
The example checked whether no methods matched 'not starting with foo or bar'. This is a double negation, it should check whether no methods match 'starting with foo or bar'.