### PR TITLE
LoggerConventions: Ignore loggers in base classes

### DIFF
--- a/src/main/java/com/enofex/taikai/logging/LoggerConventions.java
+++ b/src/main/java/com/enofex/taikai/logging/LoggerConventions.java
@@ -20,7 +20,7 @@ final class LoggerConventions {
             typeName, regex, requiredModifiers)) {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
-        for (JavaField field : javaClass.getAllFields()) {
+        for (JavaField field : javaClass.getFields()) {
           if (field.getRawType().isAssignableTo(typeName)) {
             if (!field.getName().matches(regex)) {
               events.add(SimpleConditionEvent.violated(field,

--- a/src/test/java/com/enofex/taikai/logging/LoggingConfigurerTest.java
+++ b/src/test/java/com/enofex/taikai/logging/LoggingConfigurerTest.java
@@ -36,6 +36,22 @@ class LoggingConfigurerTest {
     assertDoesNotThrow(taikai::check);
   }
 
+  /**
+   * Violations in base classes should not be reported, as the base class may be part
+   * of an external library, which is not under control of the developer.
+   */
+  @Test
+  void shouldApplyLoggerConventionsEvenIfLoggerInBaseClassDoesNotFollowConventions() {
+    Taikai taikai = Taikai.builder()
+        .classes(new ClassFileImporter().importClasses(SubClassNotViolatingConventions.class))
+        .logging(logging -> logging
+            .loggersShouldFollowConventions("java.util.logging.Logger", "logger",
+                List.of(PRIVATE, FINAL)))
+        .build();
+
+    assertDoesNotThrow(taikai::check);
+  }
+
   @Test
   void shouldThrowLoggerConventionsWithClassNaming() {
     Taikai taikai = Taikai.builder()
@@ -71,5 +87,8 @@ class LoggingConfigurerTest {
   private static class LoggerConventionsPartiallyModifier {
     private Logger logger = Logger.getLogger(
         LoggerConventionsPartiallyModifier.class.getName());
+  }
+
+  private static class SubClassNotViolatingConventions extends LoggerConventionsNotFollowedNaming {
   }
 }


### PR DESCRIPTION
Ensures that the `LoggerConventions` rule does not report violations in base classes.

This change avoids problems when loggers are inherited from an external base class, which is usually not controlled by the developer.

If the base class is part of the project, it will be checked separately anyways (and the violation will then be reported).
