### PR TITLE
Add tests for ResourcesConfigurer and ServicesConfigurer

### DIFF
--- a/src/test/java/com/enofex/taikai/quarkus/ResourcesConfigurerTest.java
+++ b/src/test/java/com/enofex/taikai/quarkus/ResourcesConfigurerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ResourcesConfigurerTest {
@@ -252,6 +253,195 @@ public class ResourcesConfigurerTest {
           .build();
 
       assertDoesNotThrow(taikai::check);
+    }
+  }
+
+  @Nested
+  class FluentChaining {
+
+    @Test
+    void shouldSupportChainingAllMethods() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r ->
+              r.namesShouldEndWithResource()
+                  .shouldBePublic()
+                  .shouldBeAnnotatedWithPath()
+                  .shouldNotDependOnOtherResources()))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldSupportChainingWithConfigurationOverloads() {
+      var config = com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration();
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r ->
+              r.namesShouldEndWithResource(config)
+                  .shouldBePublic(config)
+                  .shouldBeAnnotatedWithPath(config)
+                  .shouldNotDependOnOtherResources(config)))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldReturnNonNullFromNamesShouldMatchWithRegex() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r -> {
+            ResourcesConfigurer chained = r.namesShouldMatch(".+Resource");
+            assertNotNull(chained, "namesShouldMatch(String) must not return null");
+          }))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldReturnNonNullFromShouldBeAnnotatedWithPathWithRegex() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r -> {
+            ResourcesConfigurer chained = r.shouldBeAnnotatedWithPath(".+Resource");
+            assertNotNull(chained, "shouldBeAnnotatedWithPath(String) must not return null");
+          }))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldReturnNonNullFromShouldNotDependOnOtherResourcesNoArg() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r -> {
+            ResourcesConfigurer chained = r.shouldNotDependOnOtherResources();
+            assertNotNull(chained, "shouldNotDependOnOtherResources() must not return null");
+          }))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldReturnNonNullFromShouldNotDependOnOtherResourcesWithConfig() {
+      var config = com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration();
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r -> {
+            ResourcesConfigurer chained = r.shouldNotDependOnOtherResources(config);
+            assertNotNull(chained, "shouldNotDependOnOtherResources(Configuration) must not return null");
+          }))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldReturnNonNullFromDisable() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(r -> {
+            ResourcesConfigurer chained = r.disable();
+            assertNotNull(chained, "disable() must not return null");
+          }))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+  }
+
+  @Path("/test")
+  static public class BadController {
+  }
+
+  @Nested
+  class NegativeDelegation {
+
+    @Test
+    void shouldThrowWhenResourceNameDoesNotEndWithResource() {
+      Taikai taikai = Taikai.builder()
+          .classes(BadController.class)
+          .quarkus(quarkus -> quarkus.resources(ResourcesConfigurer::namesShouldEndWithResource))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenResourceNameDoesNotEndWithResourceWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(BadController.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.namesShouldEndWithResource(
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenResourceWithoutPathAnnotationWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(MissingRestResource.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.shouldBeAnnotatedWithPath(
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenMatchingResourceMissingPathAnnotationWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(MissingRestResource.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.shouldBeAnnotatedWithPath(".+Resource",
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenResourceIsPrivateWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(PrivateResource.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.shouldBePublic(
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenResourceDependsOnOtherResourceWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(DependentResource.class, UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.shouldNotDependOnOtherResources(
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenResourceNameDoesNotMatchRegexWithConfig() {
+      Taikai taikai = Taikai.builder()
+          .classes(UserResource.class)
+          .quarkus(quarkus -> quarkus.resources(
+              res -> res.namesShouldMatch(".+Handler",
+                  com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration())))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
     }
   }
 

--- a/src/test/java/com/enofex/taikai/spring/ServicesConfigurerTest.java
+++ b/src/test/java/com/enofex/taikai/spring/ServicesConfigurerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.enofex.taikai.Taikai;
+import com.enofex.taikai.configures.ConfigurerContext;
+import com.enofex.taikai.configures.Configurers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.stereotype.Controller;
@@ -293,5 +295,189 @@ class ServicesConfigurerTest {
 
       assertDoesNotThrow(taikai::check);
     }
+  }
+
+  @Nested
+  class FluentChaining {
+
+    private ConfigurerContext createContext() {
+      return new ConfigurerContext(null, new Configurers());
+    }
+
+    @Test
+    void namesShouldEndWithServiceShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.namesShouldEndWithService());
+    }
+
+    @Test
+    void namesShouldEndWithServiceWithConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.namesShouldEndWithService(
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void namesShouldMatchShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.namesShouldMatch(".+Service"));
+    }
+
+    @Test
+    void namesShouldMatchWithConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.namesShouldMatch(".+Service",
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void shouldBeAnnotatedWithServiceNoArgShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldBeAnnotatedWithService());
+    }
+
+    @Test
+    void shouldBeAnnotatedWithServiceWithConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldBeAnnotatedWithService(
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void shouldBeAnnotatedWithServiceWithRegexShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldBeAnnotatedWithService(".+Service"));
+    }
+
+    @Test
+    void shouldBeAnnotatedWithServiceWithRegexAndConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldBeAnnotatedWithService(".+Service",
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void shouldNotDependOnOtherServicesShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldNotDependOnOtherServices());
+    }
+
+    @Test
+    void shouldNotDependOnOtherServicesWithConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldNotDependOnOtherServices(
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void shouldNotDependOnControllersShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldNotDependOnControllers());
+    }
+
+    @Test
+    void shouldNotDependOnControllersWithConfigShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(
+          configurer.shouldNotDependOnControllers(
+              com.enofex.taikai.TaikaiRule.Configuration.defaultConfiguration()));
+    }
+
+    @Test
+    void disableShouldReturnConfigurer() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      org.junit.jupiter.api.Assertions.assertNotNull(configurer.disable());
+    }
+
+    @Test
+    void chainingMultipleRulesShouldWork() {
+      ServicesConfigurer configurer = new ServicesConfigurer(createContext());
+      ServicesConfigurer result = configurer
+          .namesShouldEndWithService()
+          .shouldBeAnnotatedWithService()
+          .shouldNotDependOnOtherServices()
+          .shouldNotDependOnControllers();
+      org.junit.jupiter.api.Assertions.assertSame(configurer, result);
+    }
+  }
+
+  @Nested
+  class MetaAnnotated {
+
+    @Test
+    void shouldNotThrowWhenServiceIsMetaAnnotated() {
+      Taikai taikai = Taikai.builder()
+          .classes(MetaAnnotatedService.class)
+          .spring(spring -> spring.services(ServicesConfigurer::namesShouldEndWithService))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenMetaAnnotatedServiceNameDoesNotMatch() {
+      Taikai taikai = Taikai.builder()
+          .classes(MetaAnnotatedBadName.class)
+          .spring(spring -> spring.services(ServicesConfigurer::namesShouldEndWithService))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldNotThrowWhenMetaAnnotatedServiceIsAnnotated() {
+      Taikai taikai = Taikai.builder()
+          .classes(MetaAnnotatedService.class)
+          .spring(spring -> spring.services(ServicesConfigurer::shouldBeAnnotatedWithService))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+
+    @Test
+    void shouldThrowWhenMetaAnnotatedServiceMissingAnnotation() {
+      Taikai taikai = Taikai.builder()
+          .classes(MissingAnnotationService.class)
+          .spring(spring -> spring.services(
+              svc -> svc.shouldBeAnnotatedWithService(".+Service")))
+          .build();
+
+      assertThrows(AssertionError.class, taikai::check);
+    }
+
+    @Test
+    void shouldNotThrowWhenMetaAnnotatedServiceDoesNotDependOnControllers() {
+      Taikai taikai = Taikai.builder()
+          .classes(MetaAnnotatedService.class)
+          .spring(spring -> spring.services(ServicesConfigurer::shouldNotDependOnControllers))
+          .build();
+
+      assertDoesNotThrow(taikai::check);
+    }
+  }
+
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE)
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  @Service
+  @interface CustomService {
+  }
+
+  @CustomService
+  static class MetaAnnotatedService {
+  }
+
+  @CustomService
+  static class MetaAnnotatedBadName {
   }
 }


### PR DESCRIPTION
Following up on #306, this adds unit tests for two more configurers, covering previously-untested rule paths using only the public Taikai API. No production code is changed.

ResourcesConfigurer (quarkus): resource naming, Path-annotation presence, public/private visibility, regex name matching, and inter-resource dependency rules, plus the disable and method-chaining configuration paths.

ServicesConfigurer (spring): service naming and Service-annotation rules, dependency constraints (no dependency on other services, controllers, or rest controllers), regex name matching, and the disable and configurer-return paths.

All tests pass: mvn test on JDK 17.