### PR TITLE
Add unit tests for Modifiers, SerialVersionUID, Taikai and TaikaiRule

### DIFF
--- a/src/test/java/com/enofex/taikai/TaikaiRuleTest.java
+++ b/src/test/java/com/enofex/taikai/TaikaiRuleTest.java
@@ -215,4 +215,21 @@ class TaikaiRuleTest {
 
     assertNotNull(rule.javaClasses("com.enofex.taikai", null, null));
   }
+
+  @Test
+  void shouldFilterExcludedClassesFromConfigurationInJavaClasses() {
+    ArchRule archRule = mock(ArchRule.class);
+    JavaClasses rawClasses = Namespace.from("com.enofex.taikai", Namespace.IMPORT.WITHOUT_TESTS);
+    long rawCount = rawClasses.stream().count();
+
+    Configuration config = Configuration.of("com.enofex.taikai",
+        Namespace.IMPORT.WITHOUT_TESTS,
+        List.of("com.enofex.taikai.TaikaiException"));
+    TaikaiRule rule = TaikaiRule.of(archRule, config);
+
+    JavaClasses result = rule.javaClasses(null, null, null);
+    long filteredCount = result.stream().count();
+
+    assertEquals(rawCount - 1, filteredCount);
+  }
 }

--- a/src/test/java/com/enofex/taikai/TaikaiTest.java
+++ b/src/test/java/com/enofex/taikai/TaikaiTest.java
@@ -214,6 +214,18 @@ class TaikaiTest {
     assertEquals(2, taikai.excludedClasses().size());
   }
 
+  @Test
+  void shouldThrowWhenMultipleIndependentRulesAreViolated() {
+    Taikai taikai = Taikai.builder()
+        .classes(ViolatingClass.class)
+        .java(java -> java
+            .methodsShouldNotDeclareGenericExceptions()
+            .naming(naming -> naming.methodsShouldMatch("#[A-Z].*")))
+        .build();
+
+    assertThrows(AssertionError.class, taikai::checkAll);
+  }
+
   static class ViolatingClass {
 
     public void method() throws Exception {

--- a/src/test/java/com/enofex/taikai/internal/ModifiersTest.java
+++ b/src/test/java/com/enofex/taikai/internal/ModifiersTest.java
@@ -155,4 +155,18 @@ class ModifiersTest {
 
     assertFalse(Modifiers.isFieldSynthetic(this.field));
   }
+
+  @Test
+  void shouldReturnTrueWhenMethodIsSynthetic() {
+    when(this.method.getModifiers()).thenReturn(Set.of(JavaModifier.SYNTHETIC));
+
+    assertTrue(Modifiers.isMethodSynthetic(this.method));
+  }
+
+  @Test
+  void shouldReturnFalseWhenMethodIsNotSynthetic() {
+    when(this.method.getModifiers()).thenReturn(Collections.emptySet());
+
+    assertFalse(Modifiers.isMethodSynthetic(this.method));
+  }
 }

--- a/src/test/java/com/enofex/taikai/java/SerialVersionUIDTest.java
+++ b/src/test/java/com/enofex/taikai/java/SerialVersionUIDTest.java
@@ -50,6 +50,21 @@ class SerialVersionUIDTest {
     private static long serialVersionUID = 2L;
   }
 
+  @Test
+  void shouldThrowWhenSerialVersionUIDIsWrongType() {
+    Taikai taikai = Taikai.builder()
+        .classes(SerialVersionUIDWithStringType.class)
+        .java(JavaConfigurer::serialVersionUIDFieldsShouldBeStaticFinalLong)
+        .build();
+
+    assertThrows(AssertionError.class, taikai::check);
+  }
+
+  static class SerialVersionUIDWithStringType implements Serializable {
+
+    private static final String serialVersionUID = "wrong";
+  }
+
   static class ClassWithOtherConstant {
 
     private static final long SOME_CONSTANT = 42L;


### PR DESCRIPTION
## Results

Measured with PIT 1.18.0 on JDK 17, scoped to the production classes still under test, with a forced clean test recompile before each run. Base = the four affected test classes as of c951c00; With PR = the same classes plus the added tests.

| Metric | Base tests | With this PR |
|---|---|---|
| Mutation kill (PIT) | 53/57 (93.0%) | 56/57 (98.2%) |
| Line coverage (PIT) | 90/95 (95%) | 91/95 (96%) |

Scope (targetClasses): `com.enofex.taikai.internal.Modifiers`, `com.enofex.taikai.java.SerialVersionUID`, `com.enofex.taikai.Taikai`, `com.enofex.taikai.TaikaiRule`.

## What this adds

Unit tests only, appended to existing test classes, covering previously unkilled branches:
- `Modifiers.isMethodSynthetic` for a synthetic method and a plain method.
- `serialVersionUIDFieldsShouldBeStaticFinalLong` rejects a `serialVersionUID` declared with a non-`long` type.
- `Taikai.checkAll` throws when two independent rules are violated. This asserts the observable contract (an `AssertionError` is raised) and deliberately does not match the human-readable violation-count message.
- `TaikaiRule.javaClasses` filters the classes named in `Configuration.excludedClasses`, removing exactly the one excluded class.

## Test data

The added tests define small in-test fixture classes only (for example a `Serializable` type whose `serialVersionUID` is a `String`, and a type excluded via configuration). No shared fixtures or resource files are added or changed.

## Scope

Tests-only. No production, build, or configuration changes; four test files touched.

## Disclosure

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant; where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant.